### PR TITLE
Add TripSegment parameter to departureCanceled callback method

### DIFF
--- a/src/ios/PIOTripSegment.h
+++ b/src/ios/PIOTripSegment.h
@@ -3,8 +3,8 @@
 //  PredictIOSDK
 //
 //  Created by Abdul Haseeb on 8/8/16.
-// Copyright (c) 2016 predict.io by ParkTAG GmbH. All rights reserved.
-//
+//  Copyright (c) 2016 predict.io by ParkTAG GmbH. All rights reserved.
+//  SDK Version 3.1.0
 
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
@@ -52,6 +52,9 @@ typedef NS_ENUM(int, LogLevel)  {
 
 @interface PIOTripSegment : NSObject
 
+/** @brief Trip Segment UUID */
+@property (strong, readonly) NSString *UUID;
+
 /** @brief Location from where the user departed */
 @property (strong, readonly) CLLocation *departureLocation;
 
@@ -67,14 +70,11 @@ typedef NS_ENUM(int, LogLevel)  {
 /** @brief Predicted mode of transport */
 @property (assign, readonly) TransportationMode transportationMode;
 
-/** @brief Trip Segment UUID */
-@property (strong, readonly) NSString *UUID;
-
-- (id)initWithDepartureLocation:(CLLocation *)departureLocation
-                arrivalLocation:(CLLocation *)arrivalLocation
-                  departureTime:(NSDate *)departureTime
-                    arrivalTime:(NSDate *)arrivalTime
-             transportationMode:(TransportationMode)transportationMode
-                           UUID:(NSString *)UUID;
+- (id)initWithUUID:(NSString *)UUID
+ departureLocation:(CLLocation *)departureLocation
+   arrivalLocation:(CLLocation *)arrivalLocation
+     departureTime:(NSDate *)departureTime
+       arrivalTime:(NSDate *)arrivalTime
+transportationMode:(TransportationMode)transportationMode;
 
 @end

--- a/src/ios/PredictIO.h
+++ b/src/ios/PredictIO.h
@@ -4,7 +4,7 @@
 //
 //  Created by Zee on 28/02/2013.
 //  Copyright (c) 2016 predict.io by ParkTAG GmbH. All rights reserved.
-//  Version 3.0.0
+//  SDK Version 3.1.0
 
 #import <Foundation/Foundation.h>
 #import "PIOTripSegment.h"
@@ -49,6 +49,18 @@
  */
 - (NSString *)deviceIdentifier;
 
+/* Set custom parameters which can then be sent to a user defined webhook url
+ * @param key:   Key to identify a custom parameter value
+ * @param value: Custom parameter value
+ */
+- (void)setCustomParameter:(NSString *)key andValue:(NSString *)value;
+
+/* Set a webhook url where all the detected events can then be forwarded along with the custom parameters.
+ * This webhook will not support additional authentication. So any additional validation of legitimate requests must take place.
+ * @param url: The webhook url
+ */
+- (void)setWebhookURL:(NSString *)url;
+
 @end
 
 @protocol PredictIODelegate <NSObject>
@@ -57,31 +69,42 @@
 
 /* This method is invoked when predict.io detects that the user is about to depart
  * from his location and is approaching to his vehicle
- * @param tripSegment: PIOTripSegment having departing event information
- * @discussion: At this point only following properties will be populated,
- *   departureLocation: The Location from where the user departed
- *   transportationMode:  Mode of transportation
+ * @param tripSegment: PIOTripSegment contains details about departing event
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
+ *  departureLocation: The Location from where the user departed
  */
 - (void)departing:(PIOTripSegment *)tripSegment;
 
 /* This method is invoked when predict.io detects that the user has just departed
  * from his location and have started a new trip
- * @param tripSegment: PIOTripSegment have departed event information
- * @discussion: At this point only following properties will be populated,
- *   departureLocation: The Location from where the user departed
- *   departureTime: Start time of the trip
- *   transportationMode: Mode of transportation
+ * @param tripSegment: PIOTripSegment contains details about departure event
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
+ *  departureLocation: The Location from where the user departed
+ *  departureTime: Time of departure
  */
 - (void)departed:(PIOTripSegment *)tripSegment;
 
 /* This method is invoked when predict.io is unable to validate the last departure event.
  * This can be due to invalid data received from sensors or the trip amplitude.
- * i.e. If the trip takes less than 5 minutes or the distance travelled is less than 3km
+ * i.e. If the trip takes less than 2 minutes or the distance travelled is less than 1km
+ * @param tripSegment: PIOTripSegment have departureCanceled event information
+ * @discussion: At this point only following properties will be populated,
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and departure canceled events
+ *  departureLocation: The Location from where the user departed
+ *  departureTime: Start time of the trip
+ *  transportationMode: Mode of transportation
  */
-- (void)departureCanceled;
+- (void)departureCanceled:(PIOTripSegment *)tripSegment;
 
 /* This method is invoked when predict.io detects transportation mode
- * @param: transportationMode: Mode of transportation
+ * @param tripSegment: PIOTripSegment contains details about user's transportation mode
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
+ *  departureLocation: The Location from where the user departed
+ *  departureTime: Time of departure
+ *  transportationMode: Mode of transportation
  */
 - (void)transportationMode:(PIOTripSegment *)tripSegment;
 
@@ -89,23 +112,25 @@
  * at his location and have ended a trip
  * Most of the time it is followed by a confirmed arrivedAtLocation event
  * If you need only confirmed arrival events, use arrivedAtLocation method (below) instead
- * @param tripSegment: PIOTripSegment have arrivalSuspected event information
- * @discussion: At this point only following properties will be populated,
+ * @param tripSegment: PIOTripSegment contains details about arrival suspected event
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
  *  departureLocation: The Location from where the user departed
  *  arrivalLocation: The Location where the user arrived and ended the trip
- *  departureTime: Start time of trip
- *  arrivalTime: Stop time of trip
+ *  departureTime: Time of departure
+ *  arrivalTime: Time of arrival
  *  transportationMode: Mode of transportation
  */
 - (void)arrivalSuspected:(PIOTripSegment *)tripSegment;
 
 /* This method is invoked when predict.io detects that the user has just arrived at destination
- * @param tripSegment: PIOTripSegment have arrived event information
- * @discussion: At this point only following properties will be populated,
+ * @param tripSegment: PIOTripSegment contains details about arrival event
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
  *  departureLocation: The Location from where the user departed
  *  arrivalLocation: The Location where the user arrived and ended the trip
- *  departureTime: Start time of trip
- *  arrivalTime: Stop time of trip
+ *  departureTime: Time of departure
+ *  arrivalTime: Time of arrival
  *  transportationMode: Mode of transportation
  */
 - (void)arrived:(PIOTripSegment *)tripSegment;

--- a/src/ios/PredictIOPlugin.h
+++ b/src/ios/PredictIOPlugin.h
@@ -43,4 +43,18 @@
  **/
 - (void)deviceIdentifier:(CDVInvokedUrlCommand*)command;
 
+/*
+ * Set custom parameters which can then be sent to a user defined webhook url
+ * @param key:   Key to identify a custom parameter value
+ * @param value: Custom parameter value
+ */
+- (void)setCustomParameter:(CDVInvokedUrlCommand*)command;
+
+/*
+ * Set a webhook url where all the detected events can then be forwarded along with the custom parameters.
+ * This webhook will not support additional authentication. So any additional validation of legitimate requests must take place.
+ * @param url: The webhook url
+ */
+- (void)setWebhookURL:(CDVInvokedUrlCommand*)command;
+
 @end

--- a/src/ios/PredictIOPlugin.h
+++ b/src/ios/PredictIOPlugin.h
@@ -1,10 +1,9 @@
 //
 //  PredictIOPlugin.h
-//  PhoneGapSample
 //
 //  Created by PredictIO on 21/06/2016.
-//
-//
+//  Copyright (c) 2016 predict.io by ParkTAG GmbH. All rights reserved.
+//  SDK Version 3.1.0
 
 #import <Cordova/CDV.h>
 #import "PredictIO.h"

--- a/src/ios/PredictIOPlugin.m
+++ b/src/ios/PredictIOPlugin.m
@@ -123,10 +123,23 @@
 /* This method is invoked when predict.io is unable to validate the last departure event.
  * This can be due to invalid data received from sensors or the trip amplitude.
  * i.e. If the trip takes less than 5 minutes or the distance travelled is less than 3km
+ * @param departureLocation: The Location from where the user departed
+ * @param departureTime: Start time of the trip
+ * @param transportMode: Mode of transport
+ * @param UUID: Trip segment UUID
  */
-- (void)departureCanceled
+- (void)departureCanceled:(PIOTripSegment *)tripSegment
 {
-    [self evaluateJSMethod:@"departureCanceled" params:nil];
+    NSMutableDictionary *departureCanceledData = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                                  @(tripSegment.departureLocation.coordinate.latitude), @"departureLatitude",
+                                                  @(tripSegment.departureLocation.coordinate.longitude), @"departureLongitude",
+                                                  @([tripSegment.departureTime timeIntervalSince1970]), @"departureTime",
+                                                  [self transportMode:tripSegment.transportationMode], @"transportationMode",
+                                                  tripSegment.UUID, @"UUID",
+                                                  nil];
+
+    NSString *params = [self jsonSerializeDictionary:departureCanceledData];
+    [self evaluateJSMethod:@"departureCanceled" params:params];
 }
 
 /* This method is invoked when predict.io detects transportation mode

--- a/src/ios/PredictIOPlugin.m
+++ b/src/ios/PredictIOPlugin.m
@@ -1,10 +1,9 @@
 //
 //  PredictIOPlugin.m
-//  PhoneGapSample
 //
 //  Created by PredictIO on 14/02/2015.
-//
-//
+//  Copyright (c) 2016 predict.io by ParkTAG GmbH. All rights reserved.
+//  SDK Version 3.1.0
 
 #import "PredictIOPlugin.h"
 #import "PredictIO.h"

--- a/src/ios/PredictIOPlugin.m
+++ b/src/ios/PredictIOPlugin.m
@@ -78,6 +78,33 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)setCustomParameter:(CDVInvokedUrlCommand*)command {
+    if ([self isValidStringArguments:command.arguments numOfArgs:2]) {
+        NSString *key = command.arguments[0];
+        NSString *value = command.arguments[1];
+        [[PredictIO sharedInstance] setCustomParameter:key andValue:value];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    } else {
+        NSString *errorMsg = [self errorMessageInValidCustomParameterArguments:command.arguments];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMsg];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }
+}
+
+- (void)setWebhookURL:(CDVInvokedUrlCommand*)command {
+    if ([self isValidStringArguments:command.arguments numOfArgs:1]) {
+        NSString *webhookUrl = command.arguments[0];
+        [[PredictIO sharedInstance] setWebhookURL:webhookUrl];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    } else {
+        NSString *errorMsg = [self errorMessageInValidWebhookArguments:command.arguments];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMsg];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }
+}
+
 #pragma mark - PredictIODelegate Methods
 
 /* This method is invoked when predict.io detects that the user is about to depart
@@ -280,6 +307,42 @@
     }
 
     [self.commandDelegate evalJs:jsStatement];
+}
+
+- (BOOL)isValidStringArguments:(NSArray *)arguments numOfArgs:(NSUInteger)numOfArgs {
+    if (arguments == nil || arguments.count != numOfArgs) {
+        return NO;
+    } else {
+        for (int index = 0; index<numOfArgs; index++) {
+            if (![arguments[index] isKindOfClass:[NSString class]]) {
+                return NO;
+            }
+        }
+    }
+    return YES;
+}
+
+- (NSString *)errorMessageInValidCustomParameterArguments:(NSArray *)arguments {
+    if (arguments == nil || arguments.count != 2) {
+        return @"Expecting two parameters, a key and a value";
+    } else {
+        if (![arguments[0] isKindOfClass:[NSString class]] ||
+            ![arguments[1] isKindOfClass:[NSString class]]) {
+            return @"Arguments can only be of string type";
+        }
+    }
+    return nil;
+}
+
+- (NSString *)errorMessageInValidWebhookArguments:(NSArray *)arguments {
+    if (arguments == nil || arguments.count != 1) {
+        return @"Expecting one parameter, a webhook url string";
+    } else {
+        if (![arguments[0] isKindOfClass:[NSString class]]) {
+            return @"Argument can only be of string type";
+        }
+    }
+    return nil;
 }
 
 @end


### PR DESCRIPTION
In predict.io sdk 3.0.2, we added the parameter TripSegment to departureCanceled callback. We are now doing the same for the cordova plugin.
